### PR TITLE
Update refs to remove dims repo reference post migration to sigs org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ test:
 
 .PHONY: bin
 bin: fmt vet
-	go build -o bin/community_images github.com/dims/community-images/cmd/community_images
+	go build -o bin/community_images github.com/kubernetes-sigs/community-images/cmd/community_images
 
 .PHONY: fmt
 fmt:

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ kubectl community-images
 
 ### Alternatives to krew
 
-- [Download binaries from a recent release](https://github.com/dims/community-images/releases):
+- [Download binaries from a recent release](https://github.com/kubernetes-sigs/community-images/releases):
 - Use `go install` to build the binary
 ````
-go install github.com/dims/community-images/cmd/community_images@latest
+go install github.com/kubernetes-sigs/community-images/cmd/community_images@latest
 $GOPATH/bin/community_images
 ````
 

--- a/cmd/community_images/cli/header.go
+++ b/cmd/community_images/cli/header.go
@@ -19,7 +19,7 @@ package cli
 import (
 	"fmt"
 
-	"github.com/dims/community-images/pkg/community_images"
+	"github.com/kubernetes-sigs/community-images/pkg/community_images"
 )
 
 func headerLine(host string) string {

--- a/cmd/community_images/cli/root.go
+++ b/cmd/community_images/cli/root.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dims/community-images/pkg/community_images"
-	"github.com/dims/community-images/pkg/logger"
+	"github.com/kubernetes-sigs/community-images/pkg/community_images"
+	"github.com/kubernetes-sigs/community-images/pkg/logger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	spin "github.com/tj/go-spin"

--- a/cmd/community_images/main.go
+++ b/cmd/community_images/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"github.com/dims/community-images/cmd/community_images/cli"
+	"github.com/kubernetes-sigs/community-images/cmd/community_images/cli"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 

--- a/deploy/.goreleaser.yaml
+++ b/deploy/.goreleaser.yaml
@@ -18,9 +18,9 @@ builds:
       - GO111MODULE=on
     main: cmd/community_images/main.go
     ldflags: -s -w
-      -X github.com/dims/community-images/pkg/version.version={{.Version}}
-      -X github.com/dims/community-images/pkg/version.gitSHA={{.Commit}}
-      -X github.com/dims/community-images/pkg/version.buildTime={{.Date}}
+      -X github.com/kubernetes-sigs/community-images/pkg/version.version={{.Version}}
+      -X github.com/kubernetes-sigs/community-images/pkg/version.gitSHA={{.Commit}}
+      -X github.com/kubernetes-sigs/community-images/pkg/version.buildTime={{.Date}}
       -extldflags "-static"
     flags: -tags netgo -installsuffix netgo
     binary: community-images

--- a/deploy/krew/community_images.yaml
+++ b/deploy/krew/community_images.yaml
@@ -9,7 +9,7 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    {{addURIAndSha "https://github.com/dims/community-images/releases/download/{{ .TagName }}/community-images_linux_amd64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/kubernetes-sigs/community-images/releases/download/{{ .TagName }}/community-images_linux_amd64.tar.gz" .TagName }}
     files:
     - from: community-images
       to: .
@@ -20,7 +20,7 @@ spec:
       matchLabels:
         os: linux
         arch: arm64
-    {{addURIAndSha "https://github.com/dims/community-images/releases/download/{{ .TagName }}/community-images_linux_arm64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/kubernetes-sigs/community-images/releases/download/{{ .TagName }}/community-images_linux_arm64.tar.gz" .TagName }}
     files:
     - from: community-images
       to: .
@@ -31,7 +31,7 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    {{addURIAndSha "https://github.com/dims/community-images/releases/download/{{ .TagName }}/community-images_darwin_amd64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/kubernetes-sigs/community-images/releases/download/{{ .TagName }}/community-images_darwin_amd64.tar.gz" .TagName }}
     files:
     - from: community-images
       to: .
@@ -42,7 +42,7 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-    {{addURIAndSha "https://github.com/dims/community-images/releases/download/{{ .TagName }}/community-images_darwin_arm64.tar.gz" .TagName }}
+    {{addURIAndSha "https://github.com/kubernetes-sigs/community-images/releases/download/{{ .TagName }}/community-images_darwin_arm64.tar.gz" .TagName }}
     files:
     - from: community-images
       to: .
@@ -53,7 +53,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    {{addURIAndSha "https://github.com/dims/community-images/releases/download/{{ .TagName }}/community-images_windows_amd64.zip" .TagName }}
+    {{addURIAndSha "https://github.com/kubernetes-sigs/community-images/releases/download/{{ .TagName }}/community-images_windows_amd64.zip" .TagName }}
     files:
     - from: community-images.exe
       to: .
@@ -61,7 +61,7 @@ spec:
       to: .
     bin: community-images.exe
   shortDescription: List community owned container images running
-  homepage: https://github.com/dims/community-images
+  homepage: https://github.com/kubernetes-sigs/community-images
   description: |
     The plugin will scan for all pods in all namespaces that you have at least
     read access to. The output is a list of all images, with the community
@@ -70,4 +70,4 @@ spec:
 
     For additional options:
       $ kubectl community-images --help
-      or https://github.com/dims/community-images/blob/master/doc/USAGE.md
+      or https://github.com/kubernetes-sigs/community-images/blob/master/doc/USAGE.md

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dims/community-images
+module github.com/kubernetes-sigs/community-images
 
 go 1.19
 


### PR DESCRIPTION
Update refs to remove dims repo reference post migration to sigs org in order to avoid issue in further release/developement. 