### PR TITLE
fix invalid module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kuernetes-sigs/community-images
+module github.com/kubernetes-sigs/community-images
 
 go 1.19
 


### PR DESCRIPTION
An error was occurring when running `go mod vendor` or `go mod tidy` command due to an invalid module name.