### PR TITLE
Option to report just images from old repository

### DIFF
--- a/cmd/community_images/cli/header.go
+++ b/cmd/community_images/cli/header.go
@@ -50,3 +50,13 @@ func imageWithTag(image community_images.RunningImage) string {
 	truncatedTagName := tag
 	return fmt.Sprintf("%s:%s %s", truncatedImageName, truncatedTagName, location)
 }
+
+func imageWithTagPlain(image community_images.RunningImage) string {
+	repo, img, tag, err := community_images.ParseImageName(image.Image)
+	if err != nil {
+		return ""
+	}
+
+	imageName := fmt.Sprintf("%s/%s", repo, img)
+	return fmt.Sprintf("%s:%s", imageName, tag)
+}

--- a/cmd/community_images/cli/root.go
+++ b/cmd/community_images/cli/root.go
@@ -47,72 +47,10 @@ func RootCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
-			log := logger.NewLogger()
-			log.Info("")
-
-			s := spin.New()
-			finishedCh := make(chan bool, 1)
-			foundImageName := make(chan string, 1)
-			go func() {
-				lastImageName := ""
-				for {
-					select {
-					case <-finishedCh:
-						fmt.Printf("\r")
-						return
-					case i := <-foundImageName:
-						lastImageName = i
-					case <-time.After(time.Millisecond * 100):
-						if lastImageName == "" {
-							fmt.Printf("\r  \033[36mSearching for images\033[m %s", s.Next())
-						} else {
-							fmt.Printf("\r  \033[36mSearching for images\033[m %s (%s)", s.Next(), lastImageName)
-						}
-					}
-				}
-			}()
-			defer func() {
-				finishedCh <- true
-			}()
-
-			imagesList, err := community_images.ListImages(KubernetesConfigFlags, foundImageName, v.GetStringSlice("ignore-ns"))
-			if err != nil {
-				log.Error(err)
-				log.Info("")
-				os.Exit(1)
-				return nil
+			if v.GetBool("plain") {
+				return runParsableCommand(v)
 			}
-			finishedCh <- true
-
-			config, _ := KubernetesConfigFlags.ToRESTConfig()
-			log.Header(headerLine(config.Host))
-			re := regexp.MustCompile(`^k8s\.gcr\.io/|^gcr\.io/google-containers`)
-			for _, runningImage := range imagesList {
-				image := imageWithTag(runningImage)
-				log.StartImageLine(image)
-				if re.MatchString(image) {
-					log.ImageRedLine(image)
-				} else {
-					log.ImageGreenLine(image)
-				}
-			}
-
-			fmt.Printf("\nImages in \033[91mred ❌ \033[mare being pulled from \033[1m*outdated*\033[0m Kubernetes community registries.\n" +
-				"The others marked in \033[92mgreen ✅ \u001B[mare good as they do not use the outdated registries.\n" +
-				"Please copy these images to your own registry and change your manifest(s)\nto point to the new location.\n\n")
-			fmt.Printf(
-				"If you are unable to do so, as a short term fix please use \033[92m`registry.k8s.io`\033[m " +
-					"\ninstead of \033[91m`k8s.gcr.io`\033[m until you have your own registry.\n\n")
-			fmt.Printf("This simple change on your part will help the Kubernetes community immensely as it\n" +
-				"reduces the cost of us serving these container images.\n")
-
-			fmt.Printf("\n\033[1mWhy you should do this as soon as possible? Read more in the following blog\n" +
-				"posts by the Kubernetes community:\033[m\n" +
-				"- https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/\n" +
-				"- https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/\n")
-
-			log.Info("")
-			return nil
+			return runPrettyCommand(v)
 		},
 	}
 
@@ -122,6 +60,7 @@ func RootCmd() *cobra.Command {
 	KubernetesConfigFlags.AddFlags(cmd.Flags())
 
 	cmd.Flags().StringSlice("ignore-ns", []string{}, "optional list of namespaces to exclude from searching")
+	cmd.Flags().Bool("plain", false, "machine parsable output (list of images from older registries ONLY)")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	return cmd
 }
@@ -138,9 +77,88 @@ func initConfig() {
 	viper.AutomaticEnv()
 }
 
-func homeDir() string {
-	if h := os.Getenv("HOME"); h != "" {
-		return h
+func runParsableCommand(v *viper.Viper) error {
+	imagesList, err := community_images.ListImages(KubernetesConfigFlags, nil, v.GetStringSlice("ignore-ns"))
+	if err != nil {
+		os.Exit(1)
+		return nil
 	}
-	return os.Getenv("USERPROFILE") // windows
+
+	re := regexp.MustCompile(`^k8s\.gcr\.io/|^gcr\.io/google-containers`)
+	for _, runningImage := range imagesList {
+		image := imageWithTagPlain(runningImage)
+		if re.MatchString(image) {
+			fmt.Println(image)
+		}
+	}
+	return nil
+}
+
+func runPrettyCommand(v *viper.Viper) error {
+	log := logger.NewLogger()
+	log.Info("")
+
+	s := spin.New()
+	finishedCh := make(chan bool, 1)
+	foundImageName := make(chan string, 1)
+	go func() {
+		lastImageName := ""
+		for {
+			select {
+			case <-finishedCh:
+				fmt.Printf("\r")
+				return
+			case i := <-foundImageName:
+				lastImageName = i
+			case <-time.After(time.Millisecond * 100):
+				if lastImageName == "" {
+					fmt.Printf("\r  \033[36mSearching for images\033[m %s", s.Next())
+				} else {
+					fmt.Printf("\r  \033[36mSearching for images\033[m %s (%s)", s.Next(), lastImageName)
+				}
+			}
+		}
+	}()
+	defer func() {
+		finishedCh <- true
+	}()
+
+	imagesList, err := community_images.ListImages(KubernetesConfigFlags, foundImageName, v.GetStringSlice("ignore-ns"))
+	if err != nil {
+		log.Error(err)
+		log.Info("")
+		os.Exit(1)
+		return nil
+	}
+	finishedCh <- true
+
+	config, _ := KubernetesConfigFlags.ToRESTConfig()
+	log.Header(headerLine(config.Host))
+	re := regexp.MustCompile(`^k8s\.gcr\.io/|^gcr\.io/google-containers`)
+	for _, runningImage := range imagesList {
+		image := imageWithTag(runningImage)
+		log.StartImageLine(image)
+		if re.MatchString(image) {
+			log.ImageRedLine(image)
+		} else {
+			log.ImageGreenLine(image)
+		}
+	}
+
+	fmt.Printf("\nImages in \033[91mred ❌ \033[mare being pulled from \033[1m*outdated*\033[0m Kubernetes community registries.\n" +
+		"The others marked in \033[92mgreen ✅ \u001B[mare good as they do not use the outdated registries.\n" +
+		"Please copy these images to your own registry and change your manifest(s)\nto point to the new location.\n\n")
+	fmt.Printf(
+		"If you are unable to do so, as a short term fix please use \033[92m`registry.k8s.io`\033[m " +
+			"\ninstead of \033[91m`k8s.gcr.io`\033[m until you have your own registry.\n\n")
+	fmt.Printf("This simple change on your part will help the Kubernetes community immensely as it\n" +
+		"reduces the cost of us serving these container images.\n")
+
+	fmt.Printf("\n\033[1mWhy you should do this as soon as possible? Read more in the following blog\n" +
+		"posts by the Kubernetes community:\033[m\n" +
+		"- https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/\n" +
+		"- https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/\n")
+
+	log.Info("")
+	return nil
 }

--- a/pkg/community_images/list.go
+++ b/pkg/community_images/list.go
@@ -59,7 +59,9 @@ func ListImages(configFlags *genericclioptions.ConfigFlags, imageNameCh chan str
 			continue
 		}
 
-		imageNameCh <- fmt.Sprintf("%s/", namespace.Name)
+		if imageNameCh != nil {
+			imageNameCh <- fmt.Sprintf("%s/", namespace.Name)
+		}
 
 		pods, err := clientset.CoreV1().Pods(namespace.Name).List(context.Background(), metav1.ListOptions{})
 		if err != nil {
@@ -80,7 +82,9 @@ func ListImages(configFlags *genericclioptions.ConfigFlags, imageNameCh chan str
 					PullableImage: pullable,
 				}
 
-				imageNameCh <- fmt.Sprintf("%s/%s", namespace.Name, runningImage.Image)
+				if imageNameCh != nil {
+					imageNameCh <- fmt.Sprintf("%s/%s", namespace.Name, runningImage.Image)
+				}
 				runningImages = append(runningImages, runningImage)
 			}
 
@@ -97,7 +101,9 @@ func ListImages(configFlags *genericclioptions.ConfigFlags, imageNameCh chan str
 					PullableImage: pullable,
 				}
 
-				imageNameCh <- fmt.Sprintf("%s/%s", namespace.Name, runningImage.Image)
+				if imageNameCh != nil {
+					imageNameCh <- fmt.Sprintf("%s/%s", namespace.Name, runningImage.Image)
+				}
 				runningImages = append(runningImages, runningImage)
 			}
 		}

--- a/pkg/community_images/list.go
+++ b/pkg/community_images/list.go
@@ -113,7 +113,8 @@ func ListImages(configFlags *genericclioptions.ConfigFlags, imageNameCh chan str
 	cleanedImages := []RunningImage{}
 	for _, runningImage := range runningImages {
 		for _, cleanedImage := range cleanedImages {
-			if cleanedImage.PullableImage == runningImage.PullableImage {
+			if cleanedImage.PullableImage == runningImage.PullableImage &&
+				cleanedImage.Image == runningImage.Image {
 				goto NextImage
 			}
 		}


### PR DESCRIPTION
Feature added for https://github.com/kubernetes-sigs/community-images/issues/47

- Adding a `--plain` command line argument to just print images with no fancy decorations so that the output is parsable (one image:tag per line)
- fix a bug found during testing (see commit message for details - tl;dr deal better with duplicate images)