### PR TITLE
fix github owner/org

### DIFF
--- a/deploy/.goreleaser.yaml
+++ b/deploy/.goreleaser.yaml
@@ -1,7 +1,7 @@
 project_name: community-images
 release:
   github:
-    owner: dims
+    owner: kubernetes-sigs
     name: community-images
 builds:
   - id: community-images


### PR DESCRIPTION
fix failure in release process: https://github.com/kubernetes-sigs/community-images/actions/runs/4490527125/jobs/7897714026

```
  • publishing
    • scm releases
      • creating or updating release                 repo=dims/community-images tag=v0.4.0
  ⨯ release failed after 8m33s               error=scm releases: failed to publish artifacts: could not release: PATCH https://api.github.com/repos/dims/community-images/releases/96494103: 404 Not Found []
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.16.2/x64/goreleaser' failed with exit code 1
```