### PR TITLE
.github/workflows: run go mod tidy when a PR is opened

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     types:
       - synchronize
+      - opened
+      - reopened
     branches:
       - main
 


### PR DESCRIPTION
`synchronize` just runs it when a new commit is pushed to a PR, not when a PR is opened/reopened.

/assign @dims 