### PR TITLE
.github/workflows: Add permission for contents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   packages: write
+  contents: write
 
 jobs:
   create-release:


### PR DESCRIPTION
The goreleaser github action requires write access to contents to be able to upload archives as GH releases.

Ref: https://goreleaser.com/ci/actions/#token-permissions

~The `GITHUB_TOKEN` secret should have read/write access for `contents` but I'm assuming its set to `restrictive` mode?
Ref: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token~

From https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions, it seems like if you specify the `permissions` key for any scope, all scoped that are not specified, default to `none`.

/assign @nikhita @palnabarun 