### PR TITLE
fix ParseImageName

### DIFF
--- a/pkg/community_images/image_name.go
+++ b/pkg/community_images/image_name.go
@@ -26,6 +26,9 @@ var (
 	dockerImageNameRegex = regexp.MustCompile("(?:([^\\/]+)\\/)?(?:([^\\/]+)\\/)?([^@:\\/]+)(?:[@:](.+))")
 )
 
+const defaultHost = "index.docker.io"
+const defaultHostAlias = "docker.io"
+
 func ParseImageName(imageName string) (string, string, string, error) {
 	matches := dockerImageNameRegex.FindStringSubmatch(imageName)
 
@@ -45,13 +48,22 @@ func ParseImageName(imageName string) (string, string, string, error) {
 		}
 	}
 
+	// docker defaulting
 	if hostname == "" {
-		hostname = "index.docker.io"
+		hostname = defaultHostAlias
 	}
 
-	if namespace == "" {
+	if namespace == "" && hasImplicitNamespace(hostname) {
 		namespace = "library"
 	}
 
-	return hostname, fmt.Sprintf("%s/%s", namespace, image), tag, nil
+	if namespace != "" {
+		image = namespace + "/" + image
+	}
+
+	return hostname, image, tag, nil
+}
+
+func hasImplicitNamespace(hostname string) bool {
+	return hostname == defaultHost || hostname == defaultHostAlias
 }

--- a/pkg/community_images/image_name_test.go
+++ b/pkg/community_images/image_name_test.go
@@ -26,14 +26,14 @@ import (
 func TestParseImageName(t *testing.T) {
 	url, image, tag, err := ParseImageName("redis:4")
 	require.NoError(t, err)
-	assert.Equal(t, "index.docker.io", url)
+	assert.Equal(t, "docker.io", url)
 	assert.Equal(t, "library/redis", image)
 	assert.Equal(t, "4", tag)
 
 	url, image, tag, err = ParseImageName("k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2-r2")
 	require.NoError(t, err)
 	assert.Equal(t, "k8s.gcr.io", url)
-	assert.Equal(t, "library/cluster-proportional-autoscaler-amd64", image)
+	assert.Equal(t, "cluster-proportional-autoscaler-amd64", image)
 	assert.Equal(t, "1.1.2-r2", tag)
 
 	url, image, tag, err = ParseImageName("quay.io/coreos/grafana-watcher:v0.0.8")
@@ -44,19 +44,19 @@ func TestParseImageName(t *testing.T) {
 
 	url, image, tag, err = ParseImageName("grafana/grafana:5.0.1")
 	require.NoError(t, err)
-	assert.Equal(t, "index.docker.io", url)
+	assert.Equal(t, "docker.io", url)
 	assert.Equal(t, "grafana/grafana", image)
 	assert.Equal(t, "5.0.1", tag)
 
 	url, image, tag, err = ParseImageName("postgres:10.0")
 	require.NoError(t, err)
-	assert.Equal(t, "index.docker.io", url)
+	assert.Equal(t, "docker.io", url)
 	assert.Equal(t, "library/postgres", image)
 	assert.Equal(t, "10.0", tag)
 
 	url, image, tag, err = ParseImageName("localhost:32000/postgres:10.0")
 	require.NoError(t, err)
 	assert.Equal(t, "localhost:32000", url)
-	assert.Equal(t, "library/postgres", image)
+	assert.Equal(t, "postgres", image)
 	assert.Equal(t, "10.0", tag)
 }


### PR DESCRIPTION
- library namespace is only inserted on docker hub images
- docker.io is typically the default name used to display dockerhub images

TODO: example screenshot needs updating. Could be a follow up though.